### PR TITLE
Use silicoin's own keychain, not chia's.

### DIFF
--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -122,7 +122,7 @@ class Keychain:
     testing: bool
     user: str
 
-    def __init__(self, user: str = "user-chia-1.8", testing: bool = False):
+    def __init__(self, user: str = "user-silicoin-1.8", testing: bool = False):
         self.testing = testing
         self.user = user
 


### PR DESCRIPTION
This change will require farmers to add their keys once again.

When attached to chia's keychain, users can easily make destructive changes to **chia** keys., and silicoin can read keys that users may wish to keep private. Please consider switching over to your own keychain.