### PR TITLE
Features/more logging and send from fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Please visit our wiki for more information:
 3. Withdraw coins from the staking address:
 
    ```
-   $ sit wallet send_from -s sit1x6jjvepyvjv7395nmtywvx9mknshgy78dsmuu38m0e9grxr080nsltjugr -t $RECEIVER
+   $ sit wallet send_from -s sit1x6jjvepyvjv7395nmtywvx9mknshgy78dsmuu38m0e9grxr080nsltjugr -t $RECEIVER -a $AMOUNT
    ```
 
    Do a transaction to transfer the coins from the staking address to any receive address.

--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ Please visit our wiki for more information:
 3. Withdraw coins from the staking address:
 
    ```
-   $ sit wallet send_from -s sit1x6jjvepyvjv7395nmtywvx9mknshgy78dsmuu38m0e9grxr080nsltjugr -t $RECEIVER -a $AMOUNT
+   $ sit wallet send_from -s sit1x6jjvepyvjv7395nmtywvx9mknshgy78dsmuu38m0e9grxr080nsltjugr -t $RECEIVER -n $NUMCOINS
    ```
 
-   Do a transaction to transfer the coins from the staking address to any receive address.
+   Do a transaction to transfer a number of coins from the staking address to any receive address.
+
+   The value of each key will depend upon how the coins were deposited to the staking address
 
    Make sure to choose the wallet that contains the plot farmer key.

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -268,6 +268,9 @@ async def summary(
                 for plot in plots["plots"]:
                     ph = create_puzzlehash_for_pk(hexstr_to_bytes(plot["farmer_public_key"]))
                     PlotStats.staking_addresses[ph] += 1
+                    if PlotStats.staking_addresses[ph] ==1:
+                        wal = encode_puzzle_hash(ph, "sit")
+                        print(f"Staking address {wal} for Farmer {plot['farmer_public_key']}")
                 print(f"   {len(plots['plots'])} plots of size: {format_bytes(total_plot_size_harvester)}")
 
         if len(harvesters_local) > 0:

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -144,7 +144,7 @@ def send_cmd(
 )
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
-@click.option("-n", "--numCoins", help="Number of coins to send, in coins not SIT", type=int, required=True)
+@click.option("-n", "--numcoins", help="Number of coins to send, in coins not SIT", type=int, required=True)
 @click.option("-s", "--source", help="Address to send the SIT from", type=str, required=True)
 @click.option("-t", "--address", help="Address to send the SIT", type=str, required=True)
 def send_from_cmd(
@@ -152,7 +152,7 @@ def send_from_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
     id: int,
-    numCoins: int,
+    numcoins: int,
     source: str,
     address: str,
 ) -> None:
@@ -160,7 +160,7 @@ def send_from_cmd(
 
     from .wallet_funcs import execute_with_wallet, send_from
 
-    extra_params = {"id": id, "numCoins": numCoins, "source": source, "address": address, "rpc_port": rpc_port}
+    extra_params = {"id": id, "numcoins": numcoins, "source": source, "address": address, "rpc_port": rpc_port}
     asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, extra_params, send_from))
 
 

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -144,13 +144,15 @@ def send_cmd(
 )
 @click.option("-f", "--fingerprint", help="Set the fingerprint to specify which wallet to use", type=int)
 @click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
-@click.option("-s", "--source", help="Address to send the XCH from", type=str, required=True)
-@click.option("-t", "--address", help="Address to send the XCH", type=str, required=True)
+@click.option("-n", "--numCoins", help="Number of coins to send, in coins not SIT", type=int, required=True)
+@click.option("-s", "--source", help="Address to send the SIT from", type=str, required=True)
+@click.option("-t", "--address", help="Address to send the SIT", type=str, required=True)
 def send_from_cmd(
     rpc_port: Optional[int],
     wallet_rpc_port: Optional[int],
     fingerprint: int,
     id: int,
+    numCoins: int,
     source: str,
     address: str,
 ) -> None:
@@ -158,7 +160,7 @@ def send_from_cmd(
 
     from .wallet_funcs import execute_with_wallet, send_from
 
-    extra_params = {"id": id, "source": source, "address": address, "rpc_port": rpc_port}
+    extra_params = {"id": id, "numCoins": numCoins, "source": source, "address": address, "rpc_port": rpc_port}
     asyncio.run(execute_with_wallet(wallet_rpc_port, fingerprint, extra_params, send_from))
 
 

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -157,6 +157,7 @@ async def print_balances(args: dict, wallet_client: WalletRpcClient, fingerprint
 
 async def send_from(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:
     wallet_id = args["id"]
+    numCoins = Decimal(args["numCoins"])
     address = decode_puzzle_hash(args["address"])
     source = decode_puzzle_hash(args["source"])
     rpc_port = args["rpc_port"]
@@ -177,8 +178,10 @@ async def send_from(args: dict, wallet_client: WalletRpcClient, fingerprint: int
 
     client.close()
     await client.await_closed()
-
-    coins = [cr.coin for cr in coin_records]
+    coins = []
+    for p in range(numCoins):
+        coins.append(coin_record[p])
+#    coins = [cr.coin for cr in coin_records]
     amount = sum(coin.amount for coin in coins)
     additions = [
         {

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -157,7 +157,7 @@ async def print_balances(args: dict, wallet_client: WalletRpcClient, fingerprint
 
 async def send_from(args: dict, wallet_client: WalletRpcClient, fingerprint: int) -> None:
     wallet_id = args["id"]
-    numCoins = Decimal(args["numCoins"])
+    numcoins = args["numcoins"]
     address = decode_puzzle_hash(args["address"])
     source = decode_puzzle_hash(args["source"])
     rpc_port = args["rpc_port"]
@@ -179,8 +179,11 @@ async def send_from(args: dict, wallet_client: WalletRpcClient, fingerprint: int
     client.close()
     await client.await_closed()
     coins = []
-    for p in range(numCoins):
-        coins.append(coin_record[p])
+
+    if numcoins > len(coin_records):
+        numcoins = len(coin_records)
+    for p in range(numcoins):
+        coins.append(coin_records[p].coin)
 #    coins = [cr.coin for cr in coin_records]
     amount = sum(coin.amount for coin in coins)
     additions = [

--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -60,7 +60,7 @@ def validate_unfinished_header_block(
     and lead to other small tweaks in validation.
     """
     # 1. Check that the previous block exists in the blockchain, or that it is correct
-
+    inHeight = height
     prev_b = blocks.try_block_record(header_block.prev_header_hash)
     genesis_block = prev_b is None
     if genesis_block and header_block.prev_header_hash != constants.GENESIS_CHALLENGE:
@@ -509,6 +509,7 @@ def validate_unfinished_header_block(
             peak_height = height - 1
         else:
             peak_height = 0
+    log.info(f"Rook inHeight: {inHeight} height: {height}")
     difficulty_coeff = blocks.get_farmer_difficulty_coeff_sync(
         header_block.reward_chain_block.proof_of_space.farmer_public_key, peak_height
     )

--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -503,13 +503,14 @@ def validate_unfinished_header_block(
         return None, None, ValidationError(Err.INVALID_SP_INDEX)
 
     # Note that required iters might be from the previous slot (if we are in an overflow block)
-    peak_height = None
-    if height is not None:
-        if height > 0:
-            peak_height = height - 1
+    if inHeight is not None and inHeight != height:
+        if inHeight > 0:
+            peak_height = inHeight - 1
         else:
             peak_height = 0
-    log.info(f"Rook inHeight: {inHeight} height: {height}")
+    else:
+        peak_height = height - 1
+       
     difficulty_coeff = blocks.get_farmer_difficulty_coeff_sync(
         header_block.reward_chain_block.proof_of_space.farmer_public_key, peak_height
     )

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -1023,11 +1023,11 @@ class Blockchain(BlockchainInterface):
                 else:
                     coeff = Decimal("0.05") + Decimal(1) / (Decimal(staking) / space + Decimal("0.05"))
 
-        # log.info(
-        #     f"minimal_staking : {minimal_staking}, space : {space} "
-        #     f"Difficulty coefficient: {coeff}, staking: {staking}, total space: {network_space}, "
-        #     f"blocks: {blocks}, peak_height: {peak_height}"
-        # )
+        log.info(
+            f"minimal_staking : {minimal_staking}, space : {space} "
+            f"Difficulty coefficient: {coeff}, staking: {staking}, total space: {network_space}, "
+            f"blocks: {blocks}, peak_height: {peak_height}"
+        )
 
         return coeff
 

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -685,7 +685,7 @@ class Farmer:
         time_slept: uint64 = uint64(0)
         refresh_slept = 0
         while not self._shut_down:
-            self.log.info("[debug] clear cache")
+#            self.log.info("[debug] clear cache")
             try:
                 if time_slept > self.constants.SUB_SLOT_TIME_TARGET:
                     now = time.time()

--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -55,6 +55,7 @@ class Harvester:
         )
         self._is_shutdown = False
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=config["num_threads"])
+        self.log.error(f"Rook Num Harvester Threads: {config['num_threads']}")
         self.state_changed_callback = None
         self.server = None
         self.constants = constants

--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -55,7 +55,6 @@ class Harvester:
         )
         self._is_shutdown = False
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=config["num_threads"])
-        self.log.error(f"Rook Num Harvester Threads: {config['num_threads']}")
         self.state_changed_callback = None
         self.server = None
         self.constants = constants

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -120,6 +120,11 @@ class HarvesterAPI:
                         )
                         sp_interval_iters = calculate_sp_interval_iters(self.harvester.constants, sub_slot_iters)
                         if required_iters < sp_interval_iters:
+                            self.harvester.log.error(
+                                    f"Rook Proof Found File: {filename} Plot ID: {plot_id.hex()}, challenge: {sp_challenge_hash}, "
+                                    f"plot_info: {plot_info}"
+                                )
+                            self.harvester.log.error(f"Rook required_iters {required_iters} sp_interval_iters {sp_interval_iters}")
                             # Found a very good proof of space! will fetch the whole proof from disk,
                             # then send to farmer
                             try:

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -27,6 +27,7 @@ class HarvesterAPI:
 
     def __init__(self, harvester: Harvester):
         self.harvester = harvester
+        self.currentDiff = 20
 
     def _set_state_changed_callback(self, callback: Callable):
         self.harvester.state_changed_callback = callback
@@ -176,6 +177,8 @@ class HarvesterAPI:
             else:
                 difficulty_coeff = Decimal(1)
 
+            self.currentDiff = difficulty_coeff
+            
             proofs_of_space_and_q: List[Tuple[bytes32, ProofOfSpace]] = await loop.run_in_executor(
                 self.harvester.executor, blocking_lookup, filename, plot_info, difficulty_coeff
             )
@@ -246,7 +249,7 @@ class HarvesterAPI:
         self.harvester.log.info(
             f"{len(awaitables)} plots were eligible for farming {new_challenge.challenge_hash.hex()[:10]}..."
             f" Found {total_proofs_found} proofs. Time: {time.time() - start:.5f} s. "
-            f"Total {self.harvester.plot_manager.plot_count()} plots"
+            f"Total {self.harvester.plot_manager.plot_count()} plots at {self.currentDiff}"
         )
 
     @api_request


### PR DESCRIPTION
Modified the send_from command to take a mandatory -n parameter representing the number of coins to transfer out.  Note:  this is number of coins, where each coin could have a different and unique value.  This gets by the issue with attempting to unstake everything all at once when you have a ton of coins in your stake.  It does not let you specify the value of sit to unstake.  