### PR TITLE
Replace Chia/XCH References with Silicoin/SIT

### DIFF
--- a/chia/cmds/init_funcs.py
+++ b/chia/cmds/init_funcs.py
@@ -72,8 +72,8 @@ def check_keys(new_root: Path, keychain: Optional[Keychain] = None) -> None:
     config: Dict = load_config(new_root, "config.yaml")
     pool_child_pubkeys = [master_sk_to_pool_sk(sk).get_g1() for sk, _ in all_sks]
     all_targets = []
-    stop_searching_for_farmer = "xch_target_address" not in config["farmer"]
-    stop_searching_for_pool = "xch_target_address" not in config["pool"]
+    stop_searching_for_farmer = "sit_target_address" not in config["farmer"]
+    stop_searching_for_pool = "sit_target_address" not in config["pool"]
     number_of_ph_to_search = 500
     selected = config["selected_network"]
     prefix = config["network_overrides"]["config"][selected]["address_prefix"]
@@ -84,41 +84,41 @@ def check_keys(new_root: Path, keychain: Optional[Keychain] = None) -> None:
             all_targets.append(
                 encode_puzzle_hash(create_puzzlehash_for_pk(master_sk_to_wallet_sk(sk, uint32(i)).get_g1()), prefix)
             )
-            if all_targets[-1] == config["farmer"].get("xch_target_address"):
+            if all_targets[-1] == config["farmer"].get("sit_target_address"):
                 stop_searching_for_farmer = True
-            if all_targets[-1] == config["pool"].get("xch_target_address"):
+            if all_targets[-1] == config["pool"].get("sit_target_address"):
                 stop_searching_for_pool = True
 
     # Set the destinations, if necessary
     updated_target: bool = False
-    if "xch_target_address" not in config["farmer"]:
+    if "sit_target_address" not in config["farmer"]:
         print(
-            f"Setting the xch destination for the farmer reward (1/8 plus fees, solo and pooling) to {all_targets[0]}"
+            f"Setting the sit destination for the farmer reward (1/8 plus fees, solo and pooling) to {all_targets[0]}"
         )
-        config["farmer"]["xch_target_address"] = all_targets[0]
+        config["farmer"]["sit_target_address"] = all_targets[0]
         updated_target = True
-    elif config["farmer"]["xch_target_address"] not in all_targets:
+    elif config["farmer"]["sit_target_address"] not in all_targets:
         print(
             f"WARNING: using a farmer address which we don't have the private"
             f" keys for. We searched the first {number_of_ph_to_search} addresses. Consider overriding "
-            f"{config['farmer']['xch_target_address']} with {all_targets[0]}"
+            f"{config['farmer']['sit_target_address']} with {all_targets[0]}"
         )
 
     if "pool" not in config:
         config["pool"] = {}
-    if "xch_target_address" not in config["pool"]:
-        print(f"Setting the xch destination address for pool reward (7/8 for solo only) to {all_targets[0]}")
-        config["pool"]["xch_target_address"] = all_targets[0]
+    if "sit_target_address" not in config["pool"]:
+        print(f"Setting the sit destination address for pool reward (7/8 for solo only) to {all_targets[0]}")
+        config["pool"]["sit_target_address"] = all_targets[0]
         updated_target = True
-    elif config["pool"]["xch_target_address"] not in all_targets:
+    elif config["pool"]["sit_target_address"] not in all_targets:
         print(
             f"WARNING: using a pool address which we don't have the private"
             f" keys for. We searched the first {number_of_ph_to_search} addresses. Consider overriding "
-            f"{config['pool']['xch_target_address']} with {all_targets[0]}"
+            f"{config['pool']['sit_target_address']} with {all_targets[0]}"
         )
     if updated_target:
         print(
-            f"To change the XCH destination addresses, edit the `xch_target_address` entries in"
+            f"To change the SIT destination addresses, edit the `sit_target_address` entries in"
             f" {(new_root / 'config' / 'config.yaml').absolute()}."
         )
 

--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -13,7 +13,7 @@ from chia.util.service_groups import services_for_groups
 
 
 def launch_start_daemon(root_path: Path) -> subprocess.Popen:
-    os.environ["CHIA_ROOT"] = str(root_path)
+    os.environ["SIT_ROOT"] = str(root_path)
     # TODO: use startupinfo=subprocess.DETACHED_PROCESS on windows
     chia = sys.argv[0]
     process = subprocess.Popen(f"{chia} run_daemon --wait-for-unlock".split(), stdout=subprocess.PIPE)

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -1158,8 +1158,8 @@ def plotter_log_path(root_path: Path, id: str):
 
 
 def launch_plotter(root_path: Path, service_name: str, service_array: List[str], id: str):
-    # we need to pass on the possibly altered CHIA_ROOT
-    os.environ["CHIA_ROOT"] = str(root_path)
+    # we need to pass on the possibly altered SIT_ROOT
+    os.environ["SIT_ROOT"] = str(root_path)
     service_executable = executable_for_service(service_array[0])
 
     # Swap service name with name of executable
@@ -1208,14 +1208,14 @@ def launch_service(root_path: Path, service_command) -> Tuple[subprocess.Popen, 
     """
     Launch a child process.
     """
-    # set up CHIA_ROOT
+    # set up SIT_ROOT
     # invoke correct script
     # save away PID
 
-    # we need to pass on the possibly altered CHIA_ROOT
-    os.environ["CHIA_ROOT"] = str(root_path)
+    # we need to pass on the possibly altered SIT_ROOT
+    os.environ["SIT_ROOT"] = str(root_path)
 
-    log.debug(f"Launching service with CHIA_ROOT: {os.environ['CHIA_ROOT']}")
+    log.debug(f"Launching service with SIT_ROOT: {os.environ['SIT_ROOT']}")
 
     # Insert proper e
     service_array = service_command.split()

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -151,13 +151,13 @@ class Farmer:
             raise RuntimeError(error_str)
 
         # This is the farmer configuration
-        self.farmer_target_encoded = self.config["xch_target_address"]
+        self.farmer_target_encoded = self.config["sit_target_address"]
         self.farmer_target = decode_puzzle_hash(self.farmer_target_encoded)
 
         self.pool_public_keys = [G1Element.from_bytes(bytes.fromhex(pk)) for pk in self.config["pool_public_keys"]]
 
         # This is the self pooling configuration, which is only used for original self-pooled plots
-        self.pool_target_encoded = self.pool_config["xch_target_address"]
+        self.pool_target_encoded = self.pool_config["sit_target_address"]
         self.pool_target = decode_puzzle_hash(self.pool_target_encoded)
         self.pool_sks_map: Dict = {}
         for key in self.get_private_keys():
@@ -534,11 +534,11 @@ class Farmer:
         if farmer_target_encoded is not None:
             self.farmer_target_encoded = farmer_target_encoded
             self.farmer_target = decode_puzzle_hash(farmer_target_encoded)
-            config["farmer"]["xch_target_address"] = farmer_target_encoded
+            config["farmer"]["sit_target_address"] = farmer_target_encoded
         if pool_target_encoded is not None:
             self.pool_target_encoded = pool_target_encoded
             self.pool_target = decode_puzzle_hash(pool_target_encoded)
-            config["pool"]["xch_target_address"] = pool_target_encoded
+            config["pool"]["sit_target_address"] = pool_target_encoded
         save_config(self._root_path, "config.yaml", config)
 
     async def set_payout_instructions(self, launcher_id: bytes32, payout_instructions: str):

--- a/chia/plotters/plotters.py
+++ b/chia/plotters/plotters.py
@@ -315,7 +315,7 @@ def build_parser(subparsers, root_path, option_list, name, plotter_desc):
 
 
 def call_plotters(root_path: Path, args):
-    # Add `plotters` section in CHIA_ROOT.
+    # Add `plotters` section in SIT_ROOT.
     chia_root_path = root_path
     root_path = get_plotters_root_path(root_path)
     if not root_path.is_dir():
@@ -326,7 +326,7 @@ def call_plotters(root_path: Path, args):
                 print(f"Exception deleting old root path: {type(e)} {e}.")
 
     if not os.path.exists(root_path):
-        print(f"Creating plotters folder within CHIA_ROOT: {root_path}")
+        print(f"Creating plotters folder within SIT_ROOT: {root_path}")
         try:
             os.mkdir(root_path)
         except Exception as e:

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -316,8 +316,8 @@ class WalletRpcApi:
             return False, False
 
         config: Dict = load_config(new_root, "config.yaml")
-        farmer_target = config["farmer"].get("xch_target_address")
-        pool_target = config["pool"].get("xch_target_address")
+        farmer_target = config["farmer"].get("sit_target_address")
+        pool_target = config["pool"].get("sit_target_address")
         found_farmer = False
         found_pool = False
         selected = config["selected_network"]

--- a/chia/server/upnp.py
+++ b/chia/server/upnp.py
@@ -33,7 +33,7 @@ class UPnP:
                             self.upnp.deleteportmapping(port, "TCP")
                         except Exception as e:
                             log.info(f"Removal of previous portmapping failed. This does not indicate an error: {e}")
-                        self.upnp.addportmapping(port, "TCP", self.upnp.lanaddr, port, "chia", "")
+                        self.upnp.addportmapping(port, "TCP", self.upnp.lanaddr, port, "silicoin", "")
                         log.info(
                             f"Port {port} opened with UPnP. lanaddr {self.upnp.lanaddr} "
                             f"external: {self.upnp.externalipaddress()}"

--- a/chia/server/upnp.py
+++ b/chia/server/upnp.py
@@ -33,7 +33,7 @@ class UPnP:
                             self.upnp.deleteportmapping(port, "TCP")
                         except Exception as e:
                             log.info(f"Removal of previous portmapping failed. This does not indicate an error: {e}")
-                        self.upnp.addportmapping(port, "TCP", self.upnp.lanaddr, port, "silicoin", "")
+                        self.upnp.addportmapping(port, "TCP", self.upnp.lanaddr, port, "sit", "")
                         log.info(
                             f"Port {port} opened with UPnP. lanaddr {self.upnp.lanaddr} "
                             f"external: {self.upnp.externalipaddress()}"

--- a/chia/util/default_root.py
+++ b/chia/util/default_root.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
 
-DEFAULT_ROOT_PATH = Path(os.path.expanduser(os.getenv("CHIA_ROOT", "~/.sit/mainnet"))).resolve()
+DEFAULT_ROOT_PATH = Path(os.path.expanduser(os.getenv("SIT_ROOT", "~/.sit/mainnet"))).resolve()
 
-DEFAULT_KEYS_ROOT_PATH = Path(os.path.expanduser(os.getenv("CHIA_KEYS_ROOT", "~/.sit_keys"))).resolve()
+DEFAULT_KEYS_ROOT_PATH = Path(os.path.expanduser(os.getenv("SIT_KEYS_ROOT", "~/.sit_keys"))).resolve()

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -114,7 +114,7 @@ harvester:
 
 pool:
   # Replace this with a real puzzle hash
-  # xch_target_address: txch102gkhhzs60grx7cfnpng5n6rjecr89r86l5s8xux2za8k820cxsq64ssdg
+  # sit_target_address: sit102gkhhzs60grx7cfnpng5n6rjecr89r86l5s8xux2za8k820cxsq64ssdg
   logging: *logging
   network_overrides: *network_overrides
   selected_network: *selected_network
@@ -134,7 +134,7 @@ farmer:
   pool_public_keys: []
 
   # Replace this with a real puzzle hash
-  # xch_target_address: txch102gkhhzs60grx7cfnpng5n6rjecr89r86l5s8xux2za8k820cxsq64ssdg
+  # sit_target_address: sit102gkhhzs60grx7cfnpng5n6rjecr89r86l5s8xux2za8k820cxsq64ssdg
 
   # If True, starts an RPC server at the following port
   start_rpc_server: True

--- a/tests/block_tools.py
+++ b/tests/block_tools.py
@@ -1296,7 +1296,7 @@ def get_challenges(
 
 
 def get_plot_dir() -> Path:
-    cache_path = Path(os.path.expanduser(os.getenv("CHIA_ROOT", "~/.chia/"))) / "test-plots"
+    cache_path = Path(os.path.expanduser(os.getenv("SIT_ROOT", "~/.chia/"))) / "test-plots"
     mkdir(cache_path)
     return cache_path
 

--- a/tests/core/test_farmer_harvester_rpc.py
+++ b/tests/core/test_farmer_harvester_rpc.py
@@ -493,7 +493,7 @@ class TestRpc:
                 master_sk_to_wallet_sk(bt.pool_master_sk, uint32(472)).get_g1()
             )
 
-            await client.set_reward_targets(encode_puzzle_hash(new_ph, "xch"), encode_puzzle_hash(new_ph_2, "xch"))
+            await client.set_reward_targets(encode_puzzle_hash(new_ph, "sit"), encode_puzzle_hash(new_ph_2, "sit"))
             targets_3 = await client.get_reward_targets(True)
             assert decode_puzzle_hash(targets_3["farmer_target"]) == new_ph
             assert decode_puzzle_hash(targets_3["pool_target"]) == new_ph_2
@@ -502,7 +502,7 @@ class TestRpc:
             new_ph_3: bytes32 = create_puzzlehash_for_pk(
                 master_sk_to_wallet_sk(bt.pool_master_sk, uint32(1888)).get_g1()
             )
-            await client.set_reward_targets(None, encode_puzzle_hash(new_ph_3, "xch"))
+            await client.set_reward_targets(None, encode_puzzle_hash(new_ph_3, "sit"))
             targets_4 = await client.get_reward_targets(True)
             assert decode_puzzle_hash(targets_4["farmer_target"]) == new_ph
             assert decode_puzzle_hash(targets_4["pool_target"]) == new_ph_3
@@ -510,10 +510,10 @@ class TestRpc:
 
             root_path = farmer_api.farmer._root_path
             config = load_config(root_path, "config.yaml")
-            assert config["farmer"]["xch_target_address"] == encode_puzzle_hash(new_ph, "xch")
-            assert config["pool"]["xch_target_address"] == encode_puzzle_hash(new_ph_3, "xch")
+            assert config["farmer"]["sit_target_address"] == encode_puzzle_hash(new_ph, "sit")
+            assert config["pool"]["sit_target_address"] == encode_puzzle_hash(new_ph_3, "sit")
 
-            new_ph_3_encoded = encode_puzzle_hash(new_ph_3, "xch")
+            new_ph_3_encoded = encode_puzzle_hash(new_ph_3, "sit")
             added_char = new_ph_3_encoded + "a"
             with pytest.raises(ValueError):
                 await client.set_reward_targets(None, added_char)

--- a/tests/setup_nodes.py
+++ b/tests/setup_nodes.py
@@ -217,10 +217,10 @@ async def setup_farmer(
     config = bt.config["farmer"]
     config_pool = bt.config["pool"]
 
-    config["xch_target_address"] = encode_puzzle_hash(b_tools.farmer_ph, "xch")
+    config["sit_target_address"] = encode_puzzle_hash(b_tools.farmer_ph, "sit")
     config["pool_public_keys"] = [bytes(pk).hex() for pk in b_tools.pool_pubkeys]
     config["port"] = port
-    config_pool["xch_target_address"] = encode_puzzle_hash(b_tools.pool_ph, "xch")
+    config_pool["sit_target_address"] = encode_puzzle_hash(b_tools.pool_ph, "sit")
 
     if full_node_port:
         config["full_node_peer"]["host"] = self_hostname

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -98,7 +98,7 @@ class TestWalletRpc:
         client = await WalletRpcClient.create(self_hostname, test_rpc_port, bt.root_path, config)
         client_node = await FullNodeRpcClient.create(self_hostname, test_rpc_port_node, bt.root_path, config)
         try:
-            addr = encode_puzzle_hash(await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(), "xch")
+            addr = encode_puzzle_hash(await wallet_node_2.wallet_state_manager.main_wallet.get_new_puzzlehash(), "sit")
             tx_amount = 15600000
             try:
                 await client.send_transaction("1", 100000000000000001, addr)
@@ -150,7 +150,7 @@ class TestWalletRpc:
             ] == initial_funds_eventually - tx_amount
 
             for i in range(0, 5):
-                await client.farm_block(encode_puzzle_hash(ph_2, "xch"))
+                await client.farm_block(encode_puzzle_hash(ph_2, "sit"))
                 await asyncio.sleep(0.5)
 
             await time_out_assert(5, eventual_balance, initial_funds_eventually - tx_amount - signed_tx_amount)
@@ -177,7 +177,7 @@ class TestWalletRpc:
             push_res = await client_node.push_tx(tx_res.spend_bundle)
             assert push_res["success"]
             for i in range(0, 5):
-                await client.farm_block(encode_puzzle_hash(ph_2, "xch"))
+                await client.farm_block(encode_puzzle_hash(ph_2, "sit"))
                 await asyncio.sleep(0.5)
 
             new_balance = initial_funds_eventually - tx_amount - signed_tx_amount - 444 - 999 - 100
@@ -199,7 +199,7 @@ class TestWalletRpc:
 
             await asyncio.sleep(3)
             for i in range(0, 5):
-                await client.farm_block(encode_puzzle_hash(ph_2, "xch"))
+                await client.farm_block(encode_puzzle_hash(ph_2, "sit"))
                 await asyncio.sleep(0.5)
 
             new_balance = new_balance - 555 - 666 - 200
@@ -250,11 +250,11 @@ class TestWalletRpc:
             sk = await wallet_node.get_key_for_fingerprint(pks[0])
             test_ph = create_puzzlehash_for_pk(master_sk_to_wallet_sk(sk, uint32(0)).get_g1())
             test_config = load_config(wallet_node.root_path, "config.yaml")
-            test_config["farmer"]["xch_target_address"] = encode_puzzle_hash(test_ph, "txch")
+            test_config["farmer"]["sit_target_address"] = encode_puzzle_hash(test_ph, "tsit")
             # set pool to second private key
             sk = await wallet_node.get_key_for_fingerprint(pks[1])
             test_ph = create_puzzlehash_for_pk(master_sk_to_wallet_sk(sk, uint32(0)).get_g1())
-            test_config["pool"]["xch_target_address"] = encode_puzzle_hash(test_ph, "txch")
+            test_config["pool"]["sit_target_address"] = encode_puzzle_hash(test_ph, "tsit")
             save_config(wallet_node.root_path, "config.yaml", test_config)
 
             # Check first key


### PR DESCRIPTION
One of my complaints about Silicoin is that it uses the `CHIA_ROOT` environment variable to determine the location of the mainnet directory. This can cause Silicoin to overwrite Chia's files, such as wallets, configs, certs and worst of all, the 40 GB blockchain database if not accounted for.

In this PR, I have replaced all instances of `CHIA_ROOT` with `SIT_ROOT`, so that users may define a custom mainnet directory location for Silicoin and Chia without them clashing with eachother. The same has been done with `CHIA_KEYS_ROOT` => `SIT_KEYS_ROOT`.

**EDIT:** Since the writing of this PR, I have added the following changes:

- Changed the UPNP name from `chia` to `sit`.
- Replaced various occurrences of `xch` with `sit`.
  - This includes a functional change: The config will now read the farmer and pool target addresses from `sit_target_address` instead of `xch_target_address`.